### PR TITLE
callTestCaseMain force listener events

### DIFF
--- a/Include/scripts/groovy/com/kms/katalon/core/keyword/builtin/CallTestCaseKeyword.groovy
+++ b/Include/scripts/groovy/com/kms/katalon/core/keyword/builtin/CallTestCaseKeyword.groovy
@@ -1,30 +1,24 @@
 package com.kms.katalon.core.keyword.builtin
 
-import groovy.transform.CompileStatic
-
 import java.text.MessageFormat
 
-import org.apache.commons.lang.math.NumberUtils
-
-import com.kms.katalon.core.annotation.Keyword
 import com.kms.katalon.core.annotation.internal.Action
+import com.kms.katalon.core.configuration.RunConfiguration
 import com.kms.katalon.core.constants.StringConstants
 import com.kms.katalon.core.exception.StepErrorException
 import com.kms.katalon.core.exception.StepFailedException
-import com.kms.katalon.core.helper.KeywordHelper
 import com.kms.katalon.core.keyword.internal.AbstractKeyword
-import com.kms.katalon.core.keyword.internal.KeywordExecutor
 import com.kms.katalon.core.keyword.internal.KeywordMain
 import com.kms.katalon.core.keyword.internal.SupportLevel
 import com.kms.katalon.core.logging.ErrorCollector
-import com.kms.katalon.core.logging.KeywordLogger
 import com.kms.katalon.core.logging.model.TestStatus
 import com.kms.katalon.core.main.TestCaseMain
 import com.kms.katalon.core.main.TestResult
 import com.kms.katalon.core.model.FailureHandling
 import com.kms.katalon.core.testcase.TestCase
 import com.kms.katalon.core.testcase.TestCaseBinding
-import com.kms.katalon.core.configuration.RunConfiguration
+
+import groovy.transform.CompileStatic
 
 @Action(value = "callTestCase")
 public class CallTestCaseKeyword extends AbstractKeyword {
@@ -43,9 +37,14 @@ public class CallTestCaseKeyword extends AbstractKeyword {
         FailureHandling flowControl = (FailureHandling)(params.length > 2 && params[2] instanceof FailureHandling ? params[2] : RunConfiguration.getDefaultFailureHandling())
         return callTestCase(calledTestCase,binding,flowControl)
     }
+    
+    @CompileStatic
+    public Object callTestCaseMain(TestCase calledTestCase, Map<String, Object> binding, FailureHandling flowControl) throws Exception {
+        callTestCase(calledTestCase, binding, flowControl, true)
+    }
 
     @CompileStatic
-    public Object callTestCase(TestCase calledTestCase, Map<String, Object> binding, FailureHandling flowControl) throws Exception {
+    public Object callTestCase(TestCase calledTestCase, Map<String, Object> binding, FailureHandling flowControl, Boolean isMain = false) throws Exception {
         KeywordMain.runKeyword({
             List<Throwable> parentErrors = ErrorCollector.getCollector().getCoppiedErrors()
             try {


### PR DESCRIPTION
@BeforeTestCase does not fire on callTestCase keywords. It's hard coded to false. Expose this boolean as optional parameter in callTestCase defaulted to false (no change). 

Created wrapper method callTestCaseMain() which passes isMain = true so event listeners fire.